### PR TITLE
feat(search): support location-based search with address and geolocation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ REDIS_PORT=6379
 # Web
 WEB_PORT=3000
 SERVER_URL=http://localhost:4000
+
+# Google Maps (required for address/location search)
+GOOGLE_MAPS_API_KEY=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,4 +184,4 @@ jobs:
             --region ${{ env.REGION }} \
             --platform managed \
             --allow-unauthenticated \
-            --set-env-vars "SERVER_URL=${{ steps.server-url.outputs.url }}"
+            --set-env-vars "SERVER_URL=${{ steps.server-url.outputs.url }},GOOGLE_MAPS_API_KEY=${{ secrets.GOOGLE_MAPS_API_KEY }}"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 .playwright-mcp/
 .vite/
 *.png
+cloud-sql-proxy

--- a/apps/server/src/trpc/gathering.ts
+++ b/apps/server/src/trpc/gathering.ts
@@ -665,24 +665,46 @@ export const gatheringRouter = createRouter({
   search: publicProcedure
     .input(searchGatheringsSchema)
     .query(async ({ input, ctx }) => {
-      const { zipCode, radius, query, gameTypes, sortBy, page, pageSize } =
-        input
+      const {
+        location,
+        locationLabel,
+        radius,
+        query,
+        gameTypes,
+        sortBy,
+        page,
+        pageSize,
+      } = input
 
-      const searchZip = await ctx.db
-        .selectFrom('zip_code_location')
-        .selectAll()
-        .where('zip_code', '=', zipCode)
-        .executeTakeFirst()
+      let lat: number
+      let lng: number
+      let searchCity: string
+      let searchState: string
 
-      if (!searchZip) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Invalid ZIP code',
-        })
+      if (location.type === 'zip') {
+        const searchZip = await ctx.db
+          .selectFrom('zip_code_location')
+          .selectAll()
+          .where('zip_code', '=', location.zipCode)
+          .executeTakeFirst()
+
+        if (!searchZip) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Invalid ZIP code',
+          })
+        }
+
+        lat = Number(searchZip.latitude)
+        lng = Number(searchZip.longitude)
+        searchCity = searchZip.city
+        searchState = searchZip.state
+      } else {
+        lat = location.lat
+        lng = location.lng
+        searchCity = ''
+        searchState = ''
       }
-
-      const lat = Number(searchZip.latitude)
-      const lng = Number(searchZip.longitude)
 
       const distanceExpr = sql<number>`(
         3959 * acos(
@@ -819,8 +841,9 @@ export const gatheringRouter = createRouter({
         page,
         pageSize,
         searchLocation: {
-          city: searchZip.city,
-          state: searchZip.state,
+          city: searchCity,
+          state: searchState,
+          label: locationLabel,
         },
       }
     }),

--- a/apps/server/tests/search.test.ts
+++ b/apps/server/tests/search.test.ts
@@ -41,7 +41,7 @@ describe('gathering.search', () => {
     })
 
     const result = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 25,
     })
 
@@ -63,7 +63,7 @@ describe('gathering.search', () => {
     })
 
     const result = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 25,
     })
 
@@ -86,7 +86,7 @@ describe('gathering.search', () => {
     })
 
     const result = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 25,
       query: 'Board Game',
     })
@@ -109,7 +109,7 @@ describe('gathering.search', () => {
     }) // linked to D&D
 
     const result = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 25,
       query: 'Catan',
     })
@@ -132,7 +132,7 @@ describe('gathering.search', () => {
     }) // ttrpg
 
     const result = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 25,
       gameTypes: ['ttrpg'],
     })
@@ -159,7 +159,7 @@ describe('gathering.search', () => {
     })
 
     const result = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 25,
       query: 'Night',
       gameTypes: ['board_game'],
@@ -188,7 +188,7 @@ describe('gathering.search', () => {
     })
 
     const page1 = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 25,
       pageSize: 2,
       page: 1,
@@ -200,7 +200,7 @@ describe('gathering.search', () => {
     expect(page1.pageSize).toBe(2)
 
     const page2 = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 25,
       pageSize: 2,
       page: 2,
@@ -213,7 +213,7 @@ describe('gathering.search', () => {
 
   it('returns empty results when no gatherings match', async () => {
     const result = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 5,
     })
 
@@ -237,7 +237,7 @@ describe('gathering.search', () => {
     })
 
     const result = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 25,
     })
 
@@ -261,7 +261,7 @@ describe('gathering.search', () => {
     })
 
     const result = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 25,
     })
 
@@ -271,7 +271,10 @@ describe('gathering.search', () => {
 
   it('throws BAD_REQUEST for an invalid ZIP code', async () => {
     await expect(
-      caller.gathering.search({ zipCode: '00000', radius: 25 }),
+      caller.gathering.search({
+        location: { type: 'zip', zipCode: '00000' },
+        radius: 25,
+      }),
     ).rejects.toThrow('Invalid ZIP code')
   })
 
@@ -296,7 +299,7 @@ describe('gathering.search', () => {
     })
 
     const result = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 25,
       sortBy: 'next_session',
     })
@@ -316,7 +319,7 @@ describe('gathering.search', () => {
     })
 
     const result = await caller.gathering.search({
-      zipCode: '10001',
+      location: { type: 'zip', zipCode: '10001' },
       radius: 25,
     })
 

--- a/apps/web/app/components/location-input.tsx
+++ b/apps/web/app/components/location-input.tsx
@@ -1,0 +1,127 @@
+import { Button } from '@game-finder/ui/components/button'
+import { Input } from '@game-finder/ui/components/input'
+import { useCallback, useState } from 'react'
+
+export type LocationValue =
+  | { mode: 'text'; text: string }
+  | { mode: 'geolocation'; lat: number; lng: number }
+
+interface LocationInputProps {
+  value: LocationValue
+  onChange: (value: LocationValue) => void
+  className?: string
+  inputClassName?: string
+}
+
+export function LocationInput({
+  value,
+  onChange,
+  className,
+  inputClassName,
+}: LocationInputProps) {
+  const [locating, setLocating] = useState(false)
+
+  const handleGeolocate = useCallback(() => {
+    if (
+      typeof navigator === 'undefined' ||
+      !('geolocation' in navigator) ||
+      locating
+    ) {
+      return
+    }
+
+    setLocating(true)
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        onChange({
+          mode: 'geolocation',
+          lat: position.coords.latitude,
+          lng: position.coords.longitude,
+        })
+        setLocating(false)
+      },
+      () => {
+        setLocating(false)
+      },
+    )
+  }, [locating, onChange])
+
+  const displayValue =
+    value.mode === 'geolocation' ? 'Current Location' : value.text
+
+  return (
+    <div className={className}>
+      <div className="flex gap-1.5">
+        <Input
+          type="text"
+          placeholder="Zip, city, or address"
+          value={displayValue}
+          onChange={(e) => onChange({ mode: 'text', text: e.target.value })}
+          className={inputClassName}
+          readOnly={value.mode === 'geolocation'}
+          onClick={() => {
+            if (value.mode === 'geolocation') {
+              onChange({ mode: 'text', text: '' })
+            }
+          }}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="shrink-0 px-2 text-muted-foreground hover:text-primary"
+          onClick={handleGeolocate}
+          disabled={locating}
+          title="Use my location"
+        >
+          {locating ? (
+            <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="h-4 w-4"
+              role="img"
+              aria-label="Use my location"
+            >
+              <path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
+              <circle cx="12" cy="10" r="3" />
+            </svg>
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function locationValueToParams(value: LocationValue): {
+  zip?: string
+  address?: string
+  lat?: string
+  lng?: string
+  locationLabel?: string
+} {
+  if (value.mode === 'geolocation') {
+    return {
+      lat: String(value.lat),
+      lng: String(value.lng),
+      locationLabel: 'Current Location',
+    }
+  }
+
+  const text = value.text.trim()
+  if (/^\d{5}$/.test(text)) {
+    return { zip: text }
+  }
+
+  if (text) {
+    return { address: text }
+  }
+
+  return {}
+}

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -4,6 +4,11 @@ import { Input } from '@game-finder/ui/components/input'
 import { Logo } from '@game-finder/ui/components/logo'
 import { Fragment, useState } from 'react'
 import { useNavigate, useRouteLoaderData, useSearchParams } from 'react-router'
+import {
+  LocationInput,
+  type LocationValue,
+  locationValueToParams,
+} from '../components/location-input.js'
 import { MapBackground } from '../components/map-background.js'
 
 const POPULAR_TAGS = [
@@ -15,64 +20,68 @@ const POPULAR_TAGS = [
 ]
 
 const HOW_IT_WORKS = [
-  { icon: '🔍', label: 'Search', desc: 'Find games by zip code & type' },
+  { icon: '🔍', label: 'Search', desc: 'Find games by location & type' },
   { icon: '📜', label: 'Browse', desc: 'Read details & check availability' },
   { icon: '⚔', label: 'Join', desc: 'Contact the host & roll initiative' },
 ]
 
 function SearchCard() {
-  const [zip, setZip] = useState('')
+  const [location, setLocation] = useState<LocationValue>({
+    mode: 'text',
+    text: '',
+  })
   const [query, setQuery] = useState('')
-  const [zipError, setZipError] = useState('')
   const navigate = useNavigate()
+
+  function buildLocationParams(): URLSearchParams {
+    const params = new URLSearchParams()
+    const locParams = locationValueToParams(location)
+    for (const [key, value] of Object.entries(locParams)) {
+      if (value) params.set(key, value)
+    }
+    return params
+  }
 
   function handleSearch(e: React.FormEvent) {
     e.preventDefault()
-    if (!zip || !/^\d{5}$/.test(zip)) {
-      setZipError('Please enter a valid 5-digit ZIP code')
-      return
-    }
-    setZipError('')
-    const params = new URLSearchParams()
-    params.set('zip', zip)
+    const locParams = locationValueToParams(location)
+    if (!locParams.zip && !locParams.lat && !locParams.address) return
+
+    const params = buildLocationParams()
     if (query) params.set('q', query)
     navigate(`/search?${params.toString()}`)
   }
 
   function handleTagClick(tag: string) {
-    const params = new URLSearchParams()
-    if (zip) params.set('zip', zip)
+    const locParams = locationValueToParams(location)
+    if (!locParams.zip && !locParams.lat && !locParams.address) return
+    const params = buildLocationParams()
     params.set('q', tag)
     navigate(`/search?${params.toString()}`)
   }
 
   return (
     <div className="bg-white/[0.04] border border-[rgba(255,191,71,0.15)] rounded-xl p-5 max-w-[420px] mx-auto">
-      <form
-        onSubmit={handleSearch}
-        className="flex flex-col md:flex-row gap-2 mb-3"
-      >
-        <Input
-          type="text"
-          placeholder="Zip Code"
-          maxLength={5}
-          value={zip}
-          onChange={(e) => setZip(e.target.value)}
-          className="w-full md:w-28"
+      <form onSubmit={handleSearch} className="flex flex-col gap-2 mb-3">
+        <LocationInput
+          value={location}
+          onChange={setLocation}
+          inputClassName="w-full"
         />
-        <Input
-          type="text"
-          placeholder="Game type..."
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          className="flex-1"
-        />
-        <Button type="submit" size="sm">
-          Search
-        </Button>
+        <div className="flex gap-2">
+          <Input
+            type="text"
+            placeholder="Game type..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="flex-1"
+          />
+          <Button type="submit" size="sm">
+            Search
+          </Button>
+        </div>
       </form>
 
-      {zipError && <p className="text-sm text-destructive mb-2">{zipError}</p>}
       <div className="flex flex-wrap gap-1.5">
         {POPULAR_TAGS.map((tag) => (
           <Badge

--- a/apps/web/app/routes/search.tsx
+++ b/apps/web/app/routes/search.tsx
@@ -19,10 +19,16 @@ import {
   SelectValue,
 } from '@game-finder/ui/components/select'
 import { useState } from 'react'
-import { Link, useNavigation, useSearchParams } from 'react-router'
+import { Link, redirect, useNavigation, useSearchParams } from 'react-router'
 import { ClientDate, SCHEDULE_LABELS } from '../components/client-date.js'
+import {
+  LocationInput,
+  type LocationValue,
+  locationValueToParams,
+} from '../components/location-input.js'
 import { MapBackground } from '../components/map-background.js'
 import { createServerTRPC } from '../trpc/server.js'
+import { geocodeAddress } from '../utils/geocode.server.js'
 import type { Route } from './+types/search.js'
 
 type GameType = 'board_game' | 'ttrpg' | 'card_game'
@@ -38,9 +44,53 @@ const RADIUS_OPTIONS = [5, 10, 25, 50]
 export async function loader({ request, context }: Route.LoaderArgs) {
   const ctx = context as { cookie?: string }
   const url = new URL(request.url)
-  const zip = url.searchParams.get('zip') ?? ''
 
-  if (!zip) return { results: null }
+  const lat = url.searchParams.get('lat')
+  const lng = url.searchParams.get('lng')
+  const locationLabel = url.searchParams.get('locationLabel') ?? undefined
+  const zip = url.searchParams.get('zip') ?? ''
+  const address = url.searchParams.get('address') ?? ''
+
+  if (address) {
+    let geocoded: Awaited<ReturnType<typeof geocodeAddress>>
+    try {
+      geocoded = await geocodeAddress(address)
+    } catch {
+      return {
+        results: null,
+        error: 'Location lookup failed. Please try again.',
+      }
+    }
+    if (!geocoded) {
+      return {
+        results: null,
+        error: `Could not find location "${address}". Try a zip code or more specific address.`,
+      }
+    }
+    const next = new URL(url)
+    next.searchParams.delete('address')
+    next.searchParams.set('lat', String(geocoded.lat))
+    next.searchParams.set('lng', String(geocoded.lng))
+    next.searchParams.set('locationLabel', geocoded.label)
+    throw redirect(next.pathname + next.search)
+  }
+
+  const hasLocation = (lat && lng) || zip
+  if (!hasLocation) return { results: null, error: null }
+
+  let location:
+    | { type: 'coordinates'; lat: number; lng: number }
+    | { type: 'zip'; zipCode: string }
+  if (lat && lng) {
+    const latNum = Number(lat)
+    const lngNum = Number(lng)
+    if (!Number.isFinite(latNum) || !Number.isFinite(lngNum)) {
+      return { results: null, error: 'Invalid location coordinates.' }
+    }
+    location = { type: 'coordinates', lat: latNum, lng: lngNum }
+  } else {
+    location = { type: 'zip', zipCode: zip }
+  }
 
   const trpc = createServerTRPC(ctx.cookie ?? '')
   const radius = Number(url.searchParams.get('radius')) || 25
@@ -56,7 +106,8 @@ export async function loader({ request, context }: Route.LoaderArgs) {
 
   try {
     const results = await trpc.gathering.search.query({
-      zipCode: zip,
+      location,
+      locationLabel,
       radius,
       query: query || undefined,
       gameTypes: gameTypes && gameTypes.length > 0 ? gameTypes : undefined,
@@ -68,13 +119,13 @@ export async function loader({ request, context }: Route.LoaderArgs) {
     return { results, error: null }
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Search failed'
-    const isInvalidZip =
+    const isInvalidLocation =
       message.toLowerCase().includes('zip') ||
       message.toLowerCase().includes('location')
     return {
       results: null,
-      error: isInvalidZip
-        ? `Invalid ZIP code "${zip}". Please enter a valid 5-digit US ZIP code.`
+      error: isInvalidLocation
+        ? 'Could not find that location. Please try a different search.'
         : message,
     }
   }
@@ -95,11 +146,46 @@ function GameTypeBadge({ type }: { type: GameType }) {
   )
 }
 
+function formatSearchLocation(searchLocation: {
+  city: string
+  state: string
+  label?: string
+}): string {
+  if (searchLocation.label) return searchLocation.label
+  if (searchLocation.city && searchLocation.state) {
+    return `${searchLocation.city}, ${searchLocation.state}`
+  }
+  return 'your area'
+}
+
+function locationValueFromParams(searchParams: URLSearchParams): LocationValue {
+  const lat = searchParams.get('lat')
+  const lng = searchParams.get('lng')
+  const locationLabel = searchParams.get('locationLabel')
+  const zip = searchParams.get('zip')
+
+  if (lat && lng) {
+    if (locationLabel && locationLabel !== 'Current Location') {
+      return { mode: 'text', text: locationLabel }
+    }
+    return {
+      mode: 'geolocation',
+      lat: Number(lat),
+      lng: Number(lng),
+    }
+  }
+
+  if (locationLabel) {
+    return { mode: 'text', text: locationLabel }
+  }
+
+  return { mode: 'text', text: zip ?? '' }
+}
+
 export default function SearchPage({ loaderData }: Route.ComponentProps) {
   const navigation = useNavigation()
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const urlZip = searchParams.get('zip') ?? ''
   const urlRadius = Number(searchParams.get('radius')) || 25
   const urlQuery = searchParams.get('q') ?? ''
   const urlTypes = searchParams.get('types')?.split(',').filter(Boolean) as
@@ -110,11 +196,15 @@ export default function SearchPage({ loaderData }: Route.ComponentProps) {
     | 'next_session'
   const urlPage = Number(searchParams.get('page')) || 1
 
-  const [zipInput, setZipInput] = useState(urlZip)
+  const [locationInput, setLocationInput] = useState<LocationValue>(() =>
+    locationValueFromParams(searchParams),
+  )
   const [radiusInput, setRadiusInput] = useState(urlRadius)
   const [queryInput, setQueryInput] = useState(urlQuery)
 
-  const hasSearched = !!urlZip
+  const hasSearched =
+    !!searchParams.get('zip') ||
+    !!(searchParams.get('lat') && searchParams.get('lng'))
   const isLoading = navigation.state === 'loading'
   const data = loaderData.results
   const searchError = loaderData.error
@@ -133,13 +223,23 @@ export default function SearchPage({ loaderData }: Route.ComponentProps) {
 
   function handleSearch(e: React.FormEvent) {
     e.preventDefault()
-    if (!zipInput || !/^\d{5}$/.test(zipInput)) return
-    updateSearchParams({
-      zip: zipInput,
-      radius: String(radiusInput),
-      q: queryInput || undefined,
-      page: '1',
-    })
+    const locParams = locationValueToParams(locationInput)
+    if (!locParams.zip && !locParams.lat && !locParams.address) return
+
+    const newParams = new URLSearchParams()
+    for (const [key, value] of Object.entries(locParams)) {
+      if (value) newParams.set(key, value)
+    }
+    newParams.set('radius', String(radiusInput))
+    if (queryInput) newParams.set('q', queryInput)
+
+    const currentTypes = searchParams.get('types')
+    if (currentTypes) newParams.set('types', currentTypes)
+    const currentSort = searchParams.get('sort')
+    if (currentSort) newParams.set('sort', currentSort)
+
+    newParams.set('page', '1')
+    setSearchParams(newParams)
   }
 
   function toggleGameType(type: GameType) {
@@ -171,19 +271,11 @@ export default function SearchPage({ loaderData }: Route.ComponentProps) {
         <form onSubmit={handleSearch} className="mb-8">
           <div className="flex flex-wrap items-end gap-3">
             <div className="flex flex-col gap-1.5">
-              <Label htmlFor="zip" className="text-xs text-muted-foreground">
-                ZIP Code
-              </Label>
-              <Input
-                id="zip"
-                type="text"
-                placeholder="e.g. 10001"
-                value={zipInput}
-                onChange={(e) => setZipInput(e.target.value)}
-                className="w-28"
-                maxLength={5}
-                pattern="\d{5}"
-                required
+              <Label className="text-xs text-muted-foreground">Location</Label>
+              <LocationInput
+                value={locationInput}
+                onChange={setLocationInput}
+                inputClassName="w-48"
               />
             </div>
             <div className="flex flex-col gap-1.5">
@@ -231,7 +323,7 @@ export default function SearchPage({ loaderData }: Route.ComponentProps) {
         {!hasSearched && (
           <div className="flex min-h-[40vh] items-center justify-center">
             <p className="text-center text-muted-foreground">
-              Enter your ZIP code to find tabletop gatherings near you.
+              Enter a location to find tabletop gatherings near you.
             </p>
           </div>
         )}
@@ -319,7 +411,7 @@ export default function SearchPage({ loaderData }: Route.ComponentProps) {
                 <>
                   <p className="mb-4 text-sm text-muted-foreground">
                     {data.total} gathering{data.total !== 1 ? 's' : ''} near{' '}
-                    {data.searchLocation.city}, {data.searchLocation.state}
+                    {formatSearchLocation(data.searchLocation)}
                   </p>
 
                   {data.gatherings.length === 0 ? (

--- a/apps/web/app/utils/geocode.server.ts
+++ b/apps/web/app/utils/geocode.server.ts
@@ -1,0 +1,51 @@
+export type GeocodeResult = {
+  lat: number
+  lng: number
+  label: string
+}
+
+function getApiKey(): string {
+  const key = process.env.GOOGLE_MAPS_API_KEY
+  if (!key) {
+    throw new Error('GOOGLE_MAPS_API_KEY environment variable is required')
+  }
+  return key
+}
+
+export async function geocodeAddress(
+  address: string,
+): Promise<GeocodeResult | null> {
+  const url = new URL('https://maps.googleapis.com/maps/api/geocode/json')
+  url.searchParams.set('address', address)
+  url.searchParams.set('key', getApiKey())
+
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Geocoding API error: ${response.status}`)
+  }
+
+  const data = (await response.json()) as {
+    status: string
+    results: Array<{
+      geometry: { location: { lat: number; lng: number } }
+      formatted_address: string
+    }>
+  }
+
+  if (data.status === 'ZERO_RESULTS' || data.results.length === 0) {
+    return null
+  }
+
+  if (data.status !== 'OK') {
+    throw new Error(`Geocoding API returned status: ${data.status}`)
+  }
+
+  const first = data.results[0]
+  if (!first) return null
+
+  return {
+    lat: first.geometry.location.lat,
+    lng: first.geometry.location.lng,
+    label: first.formatted_address,
+  }
+}

--- a/packages/contracts/src/search.ts
+++ b/packages/contracts/src/search.ts
@@ -1,8 +1,18 @@
 import { z } from 'zod'
 import { gameTypeSchema } from './game.js'
 
+export const searchLocationSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('zip'), zipCode: z.string().regex(/^\d{5}$/) }),
+  z.object({
+    type: z.literal('coordinates'),
+    lat: z.number(),
+    lng: z.number(),
+  }),
+])
+
 export const searchGatheringsSchema = z.object({
-  zipCode: z.string().regex(/^\d{5}$/, 'Must be a 5-digit ZIP code'),
+  location: searchLocationSchema,
+  locationLabel: z.string().optional(),
   radius: z.number().positive(),
   query: z.string().trim().optional(),
   gameTypes: z.array(gameTypeSchema).optional(),
@@ -41,9 +51,11 @@ export const searchGatheringsOutputSchema = z.object({
   searchLocation: z.object({
     city: z.string(),
     state: z.string(),
+    label: z.string().optional(),
   }),
 })
 
+export type SearchLocation = z.infer<typeof searchLocationSchema>
 export type SearchGatheringsInput = z.infer<typeof searchGatheringsSchema>
 export type SearchResult = z.infer<typeof searchResultSchema>
 export type SearchGatheringsOutput = z.infer<

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -32,7 +32,7 @@ fi
 update_env() {
   local key="$1" value="$2"
   if grep -q "^${key}=" .env; then
-    sed -i '' "s/^${key}=.*/${key}=${value}/" .env
+    sed -i '' "s|^${key}=.*|${key}=${value}|" .env
   else
     echo "${key}=${value}" >> .env
   fi


### PR DESCRIPTION
## Summary

- Replace zip-code-only search with flexible location input accepting zip codes, city/state names, street addresses, and browser geolocation
- Add Google Maps Geocoding API integration (server-side in SSR loader) with address → lat/lng redirect for shareable URLs
- Add shared `LocationInput` component with "Use my location" button on both homepage and search page
- Update search contract to discriminated union (`zip | coordinates`) with direct lat/lng backend support
- Fix pre-existing `worktree-setup.sh` sed delimiter bug that broke `SERVER_URL` substitution

## Test plan

- [x] Server integration tests — 54/54 passing
- [x] Typecheck — all 7 packages pass
- [x] Lint — all 7 packages pass
- [x] Playwright: zip code search returns results with correct location label
- [x] Playwright: address search geocodes, redirects to lat/lng URL, shows results
- [x] Playwright: homepage search with address + keyword navigates and filters correctly
- [x] Playwright: invalid address shows friendly error
- [x] Playwright: invalid coordinates (NaN) shows validation error
- [x] Playwright: direct lat/lng with "Current Location" label works

🤖 Generated with [Claude Code](https://claude.com/claude-code)